### PR TITLE
Better error message when config not found/invalid

### DIFF
--- a/src/yetibot/core/config.clj
+++ b/src/yetibot/core/config.clj
@@ -12,7 +12,7 @@
 ;; TODO: is there a Clojure lens lib that could make accessing and getting
 ;; updates from config easier and more idiomatic?
 
-(def config-path "config/config.edn")
+(def config-path (.getAbsolutePath (as-file "config/config.edn")))
 
 (defn config-exists? [] (.exists (as-file config-path)))
 

--- a/src/yetibot/core/init.clj
+++ b/src/yetibot/core/init.clj
@@ -29,5 +29,5 @@
       (ai/start)
       (load-commands-and-observers))
     (do
-      (error "Yetibot failed to start: please ensure config is in place at" config/config-path)
+      (error "Yetibot failed to start: please ensure config is in place at" config/config-path " and that it is well-formed (see the log above for details)")
       (shutdown-agents))))


### PR DESCRIPTION
- display the full path to the expected file
- remind the user the problem may be in the 
  content of the file (invalid .edn)